### PR TITLE
Make Wallet an impl of Clone and Copy

### DIFF
--- a/packages/cosmos/src/wallet.rs
+++ b/packages/cosmos/src/wallet.rs
@@ -130,6 +130,8 @@ impl RawWallet {
 }
 
 /// A wallet capable of signing on a specific blockchain
+#[derive(Clone)]
+// Not deriving Copy since this is a pretty large data structure.
 pub struct Wallet {
     address: Address,
     privkey: ExtendedPrivKey,


### PR DESCRIPTION
I'm not sure how I feel about this to be honest. The data type is somewhat on the large size for a Copy impl. It may make more sense to only derive Clone, and in the future consider sticking the payload behind an Arc for efficiency. Any thoughts?