### PR TITLE
cosmos-bin: increase gas multiplier when sending coins

### DIFF
--- a/packages/cosmos-bin/src/main.rs
+++ b/packages/cosmos-bin/src/main.rs
@@ -53,10 +53,10 @@ struct Opt {
         long,
         short,
         global = true,
-        default_value_t = 1.3,
-        env = "GAS_MULTIPLIER"
+        default_value = None,
+        env = "COSMOS_GAS_MULTIPLIER"
     )]
-    gas_multiplier: f64,
+    gas_multiplier: Option<f64>,
 }
 
 impl Opt {
@@ -278,7 +278,10 @@ impl Subcommand {
         }
         let cosmos = builder.build_lazy();
         let address_type = cosmos.get_address_type();
-        cosmos.set_gas_multiplier(opt.gas_multiplier);
+
+        if let Some(gas_multiplier) = opt.gas_multiplier {
+            cosmos.set_gas_multiplier(gas_multiplier);
+        }
 
         match self {
             Subcommand::StoreCode { tx_opt, file } => {

--- a/packages/cosmos-bin/src/main.rs
+++ b/packages/cosmos-bin/src/main.rs
@@ -47,6 +47,10 @@ struct Opt {
     /// Turn on verbose output
     #[clap(long, short, global = true)]
     verbose: bool,
+
+    /// Gas multiplier for simulated transactions
+    #[clap(long, short, global = true, default_value = "1.3")]
+    gas_multiplier: f64,
 }
 
 impl Opt {
@@ -268,6 +272,7 @@ impl Subcommand {
         }
         let cosmos = builder.build_lazy();
         let address_type = cosmos.get_address_type();
+        cosmos.set_gas_multiplier(opt.gas_multiplier);
 
         match self {
             Subcommand::StoreCode { tx_opt, file } => {
@@ -388,27 +393,10 @@ impl Subcommand {
                 dest,
                 coins,
             } => {
-                // gas is wildly underestimated on osmosis testnet at least
-                // bump up the multiplier to make sure we have enough
-                // then set it back when we're done sending coins
-                let original_gas_multiplier = cosmos.get_gas_multiplier();
-                if original_gas_multiplier < 1.5 {
-                    log::info!(
-                        "gas multiplier is low ({}) - increasing to 1.5 to send coins",
-                        original_gas_multiplier
-                    );
-                    cosmos.set_gas_multiplier(1.5);
-                }
-
                 let txres = tx_opt
                     .get_wallet(address_type)
                     .send_coins(&cosmos, dest, coins.into_iter().map(|x| x.into()).collect())
                     .await?;
-
-                if cosmos.get_gas_multiplier() != original_gas_multiplier {
-                    log::info!("setting gas multiplier back to {}", original_gas_multiplier);
-                    cosmos.set_gas_multiplier(original_gas_multiplier);
-                }
 
                 println!("{}", txres.txhash);
             }

--- a/packages/cosmos-bin/src/main.rs
+++ b/packages/cosmos-bin/src/main.rs
@@ -49,7 +49,13 @@ struct Opt {
     verbose: bool,
 
     /// Gas multiplier for simulated transactions
-    #[clap(long, short, global = true, default_value = "1.3")]
+    #[clap(
+        long,
+        short,
+        global = true,
+        default_value_t = 1.3,
+        env = "GAS_MULTIPLIER"
+    )]
     gas_multiplier: f64,
 }
 

--- a/packages/cosmos-bin/src/main.rs
+++ b/packages/cosmos-bin/src/main.rs
@@ -406,10 +406,7 @@ impl Subcommand {
                     .await?;
 
                 if cosmos.get_gas_multiplier() != original_gas_multiplier {
-                    log::info!(
-                        "setting gas multiplier back to {}",
-                        original_gas_multiplier
-                    );
+                    log::info!("setting gas multiplier back to {}", original_gas_multiplier);
                     cosmos.set_gas_multiplier(original_gas_multiplier);
                 }
 


### PR DESCRIPTION
same idea as what we do in perps when deploying

this only affects the binary command, the library send_coins remains pure and just uses whatever multiplier is currently set