### PR TITLE
PERP-1561 | load config

### DIFF
--- a/packages/cosmos-bin/src/main.rs
+++ b/packages/cosmos-bin/src/main.rs
@@ -78,6 +78,8 @@ async fn main() -> Result<()> {
 
 #[derive(clap::Parser)]
 enum Subcommand {
+    /// Show config
+    ShowConfig {},
     /// Upload contract
     StoreCode {
         #[clap(flatten)]
@@ -257,10 +259,13 @@ enum Subcommand {
 
 impl Subcommand {
     pub(crate) async fn go(self, opt: Opt) -> Result<()> {
-        let cosmos = opt.network_opt.build_lazy();
+        let cosmos = opt.network_opt.build_lazy().await?;
         let address_type = cosmos.get_address_type();
 
         match self {
+            Subcommand::ShowConfig {} => {
+                println!("{:#?}", cosmos.get_config())
+            }
             Subcommand::StoreCode { tx_opt, file } => {
                 let wallet = tx_opt.get_wallet(address_type);
                 let codeid = cosmos.store_code_path(&wallet, &file).await?;

--- a/packages/cosmos/src/clap.rs
+++ b/packages/cosmos/src/clap.rs
@@ -23,11 +23,11 @@ pub struct CosmosOpt {
 }
 
 impl CosmosOpt {
-    pub fn builder(&self) -> CosmosBuilder {
-        self.clone().into_builder()
+    pub async fn builder(&self) -> Result<CosmosBuilder> {
+        self.clone().into_builder().await
     }
 
-    pub fn into_builder(self) -> CosmosBuilder {
+    pub async fn into_builder(self) -> Result<CosmosBuilder> {
         let CosmosOpt {
             network,
             cosmos_grpc,
@@ -36,7 +36,7 @@ impl CosmosOpt {
             referer_header,
         } = self;
 
-        let mut builder = network.builder();
+        let mut builder = network.builder().await?;
         if let Some(grpc) = cosmos_grpc {
             builder.grpc_url = grpc;
         }
@@ -52,14 +52,14 @@ impl CosmosOpt {
             builder.set_referer_header(referer_header);
         }
 
-        builder
+        Ok(builder)
     }
 
     pub async fn build(&self) -> Result<Cosmos> {
-        self.builder().build().await
+        self.builder().await?.build().await
     }
 
-    pub fn build_lazy(&self) -> Cosmos {
-        self.builder().build_lazy()
+    pub async fn build_lazy(&self) -> Result<Cosmos> {
+        Ok(self.builder().await?.build_lazy())
     }
 }

--- a/packages/cosmos/src/client.rs
+++ b/packages/cosmos/src/client.rs
@@ -27,7 +27,7 @@ use cosmos_sdk_proto::{
     traits::Message,
 };
 use deadpool::{async_trait, managed::RecycleResult};
-use serde::de::Visitor;
+use serde::{de::Visitor, Deserialize};
 use tokio::sync::Mutex;
 use tonic::{
     codegen::InterceptedService,
@@ -199,7 +199,7 @@ pub struct CosmosBuilder {
 }
 
 /// Optional config values.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CosmosConfig {
     /// Override RPC endpoint to use instead of gRPC.
     ///
@@ -367,11 +367,11 @@ impl FromStr for CosmosNetwork {
 
 impl CosmosNetwork {
     pub async fn connect(self) -> Result<Cosmos> {
-        self.builder().build().await
+        self.builder().await?.build().await
     }
 
-    pub fn builder(self) -> CosmosBuilder {
-        match self {
+    pub async fn builder(self) -> Result<CosmosBuilder> {
+        Ok(match self {
             CosmosNetwork::JunoTestnet => CosmosBuilder::new_juno_testnet(),
             CosmosNetwork::JunoMainnet => CosmosBuilder::new_juno_mainnet(),
             CosmosNetwork::JunoLocal => CosmosBuilder::new_juno_local(),
@@ -381,10 +381,10 @@ impl CosmosNetwork {
             CosmosNetwork::Dragonfire => CosmosBuilder::new_dragonfire(),
             CosmosNetwork::WasmdLocal => CosmosBuilder::new_wasmd_local(),
             CosmosNetwork::SeiMainnet => CosmosBuilder::new_sei_mainnet(),
-            CosmosNetwork::SeiTestnet => CosmosBuilder::new_sei_testnet(),
+            CosmosNetwork::SeiTestnet => CosmosBuilder::new_sei_testnet().await?,
             CosmosNetwork::StargazeTestnet => CosmosBuilder::new_stargaze_testnet(),
             CosmosNetwork::StargazeMainnet => CosmosBuilder::new_stargaze_mainnet(),
-        }
+        })
     }
 }
 
@@ -450,6 +450,10 @@ impl CosmosBuilder {
 }
 
 impl Cosmos {
+    pub fn get_config(&self) -> &CosmosConfig {
+        &self.pool.manager().get_first_builder().config
+    }
+
     pub async fn get_base_account(&self, address: impl Into<String>) -> Result<BaseAccount> {
         let inner = self.inner().await?;
         let req = QueryAccountRequest {
@@ -952,19 +956,35 @@ impl CosmosBuilder {
             },
         }
     }
-    fn new_sei_testnet() -> CosmosBuilder {
-        CosmosBuilder {
+    async fn new_sei_testnet() -> Result<CosmosBuilder> {
+        // use reqwest to fetch the data from https://github.com/sei-protocol/testnet-registry/blob/master/gas.json
+
+        #[derive(Deserialize)]
+        struct SeiGasConfig {
+            #[serde(rename = "atlantic-2")]
+            pub atlantic_2: SeiGasConfigItem,
+        }
+        #[derive(Deserialize)]
+        struct SeiGasConfigItem {
+            pub min_gas_price: f64,
+        }
+
+        let url = "https://raw.githubusercontent.com/sei-protocol/testnet-registry/master/gas.json";
+        let resp = reqwest::get(url).await?;
+        let gas_config: SeiGasConfig = resp.json().await?;
+
+        Ok(CosmosBuilder {
             grpc_url: "https://sei-grpc.kingnodes.com".to_owned(),
             chain_id: "atlantic-2".to_owned(),
             gas_coin: "usei".to_owned(),
             address_type: AddressType::Sei,
             config: CosmosConfig {
-                // https://github.com/sei-protocol/testnet-registry/blob/master/gas.json
-                gas_price_low: 0.012,
+                gas_price_low: gas_config.atlantic_2.min_gas_price,
+                gas_price_high: gas_config.atlantic_2.min_gas_price * 2.0,
                 gas_price_retry_attempts: 6,
                 ..CosmosConfig::default()
             },
-        }
+        })
     }
 
     fn new_stargaze_testnet() -> CosmosBuilder {

--- a/packages/cosmos/src/client.rs
+++ b/packages/cosmos/src/client.rs
@@ -957,8 +957,6 @@ impl CosmosBuilder {
         }
     }
     async fn new_sei_testnet() -> Result<CosmosBuilder> {
-        // use reqwest to fetch the data from https://github.com/sei-protocol/testnet-registry/blob/master/gas.json
-
         #[derive(Deserialize)]
         struct SeiGasConfig {
             #[serde(rename = "atlantic-2")]


### PR DESCRIPTION
Real world difference is only that it remotely loads the min_gas for sei testnet

However, this also opens the door for loading more config values remotely, if we want to

This does introduce a small breaking change to consumers - they now need to call `build_lazy()` in an async context and handle the result, but this is a very minimal change and is probably already the situation they are in (e.g. in cosmos-bin here, was already setup to handle that smoothly)