### PR TITLE
Support backup chain nodes

### DIFF
--- a/packages/cosmos/src/clap.rs
+++ b/packages/cosmos/src/clap.rs
@@ -56,10 +56,10 @@ impl CosmosOpt {
     }
 
     pub async fn build(&self) -> Result<Cosmos> {
-        self.builder().await?.build().await
+        self.builder().await?.build(None).await
     }
 
     pub async fn build_lazy(&self) -> Result<Cosmos> {
-        Ok(self.builder().await?.build_lazy().await)
+        Ok(self.builder().await?.build_lazy(None).await)
     }
 }


### PR DESCRIPTION
We used to have only one pool with only one endpoint in Vec, and retry on it every where. Recent troubles showed that there might be some broken blocks in the certain node we are connecting, retry made no effect at all.

Hence this change makes full use of the framework, allowing more endpoints to be specified. And in `perform_query`, the primary pool (as `pool` used to be, contains only one endpoint) is used first. If it failed, more endpoints would be tried. Not working connections would be marked as broken. If all failed, errors from primary connection would be returned