### PR TITLE
Use a custom connection pool instead of bb8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,19 +184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bb8"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b4b0f25f18bcdc3ac72bdb486ed0acf7e185221fd4dc985bc15db5800b0ba2"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-util",
- "parking_lot",
- "tokio",
-]
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,7 +375,6 @@ name = "cosmos"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
- "bb8",
  "bech32",
  "bip39",
  "bitcoin",

--- a/packages/cosmos/Cargo.toml
+++ b/packages/cosmos/Cargo.toml
@@ -30,7 +30,6 @@ base64 = "0.21"
 parking_lot = "0.12"
 clap = { version = "4", features = ["derive", "env"], optional = true }
 bip39 = "2"
-bb8 = "0.8.1"
 thiserror = "1"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 

--- a/packages/cosmos/src/client/node_chooser.rs
+++ b/packages/cosmos/src/client/node_chooser.rs
@@ -122,33 +122,3 @@ impl Node {
         }
     }
 }
-
-/// See ManageConnection impl
-pub(super) struct NodeGuard<'a> {
-    node: &'a Node,
-    is_canceled: bool,
-}
-
-impl<'a> NodeGuard<'a> {
-    pub(super) fn new(node: &'a Node) -> Self {
-        NodeGuard {
-            node,
-            is_canceled: false,
-        }
-    }
-
-    pub(super) fn cancel(&mut self) {
-        self.is_canceled = true;
-    }
-}
-
-impl Drop for NodeGuard<'_> {
-    fn drop(&mut self) {
-        if !self.is_canceled {
-            self.node
-                .log_connection_error(ConnectionError::TimeoutConnecting {
-                    grpc_url: self.node.grpc_url.clone(),
-                })
-        }
-    }
-}

--- a/packages/cosmos/src/client/pool.rs
+++ b/packages/cosmos/src/client/pool.rs
@@ -1,0 +1,191 @@
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use parking_lot::Mutex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::{error::ConnectionError, CosmosBuilder};
+
+use super::{node_chooser::NodeChooser, CosmosInner};
+
+#[derive(Clone)]
+pub(super) struct Pool {
+    pub(super) builder: Arc<CosmosBuilder>,
+    pub(super) node_chooser: NodeChooser,
+    semaphore: Arc<Semaphore>,
+    idle: Arc<Mutex<Vec<IdleConn>>>,
+    idle_cleanup: IdleCleanup,
+}
+
+struct IdleConn {
+    conn: CosmosInner,
+    idle_start: Instant,
+}
+
+pub(super) struct CosmosInnerGuard {
+    /// Only switches to None on drop
+    pub(super) inner: Option<CosmosInner>,
+    _permit: OwnedSemaphorePermit,
+    idle: Arc<Mutex<Vec<IdleConn>>>,
+    idle_cleanup: IdleCleanup,
+}
+
+impl CosmosInnerGuard {
+    pub(crate) fn get_inner_mut(&mut self) -> &mut CosmosInner {
+        self.inner
+            .as_mut()
+            .expect("CosmosInnerGuard::get_inner_mut: inner is None")
+    }
+}
+
+impl CosmosInner {
+    fn is_expired(&self) -> bool {
+        self.expires
+            .map_or(false, |expires| expires <= tokio::time::Instant::now())
+    }
+}
+
+impl Drop for CosmosInnerGuard {
+    fn drop(&mut self) {
+        let inner = self
+            .inner
+            .take()
+            .expect("CosmosInnerGuard::drop: inner is None");
+        if !inner.is_expired() && !inner.is_broken {
+            self.idle.lock().push(IdleConn {
+                conn: inner,
+                idle_start: Instant::now(),
+            });
+            self.idle_cleanup.trigger();
+        }
+    }
+}
+
+impl Pool {
+    pub(super) async fn new(builder: Arc<CosmosBuilder>) -> Self {
+        let node_chooser = NodeChooser::new(&builder);
+        let semaphore = Arc::new(Semaphore::new(builder.connection_count()));
+        let idle = Arc::new(Mutex::new(Vec::new()));
+        let idle_cleanup = IdleCleanup::new(&builder, idle.clone()).await;
+        Pool {
+            builder,
+            node_chooser,
+            semaphore,
+            idle,
+            idle_cleanup,
+        }
+    }
+
+    pub(super) async fn get(&self) -> Result<CosmosInnerGuard, ConnectionError> {
+        let permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("Pool::get: semaphore has been closed");
+        while let Some(idle) = self.idle.lock().pop() {
+            if !idle.conn.is_expired() {
+                return Ok(CosmosInnerGuard {
+                    inner: Some(idle.conn),
+                    _permit: permit,
+                    idle: self.idle.clone(),
+                    idle_cleanup: self.idle_cleanup.clone(),
+                });
+            }
+        }
+
+        let inner = self.fresh().await?;
+        Ok(CosmosInnerGuard {
+            inner: Some(inner),
+            _permit: permit,
+            idle: self.idle.clone(),
+            idle_cleanup: self.idle_cleanup.clone(),
+        })
+    }
+
+    async fn fresh(&self) -> Result<CosmosInner, ConnectionError> {
+        let node = self.node_chooser.choose_node();
+
+        let build = self.builder.build_inner(node, &self.builder);
+        let build = tokio::time::timeout(self.builder.connection_timeout(), build);
+
+        match build.await {
+            Ok(Ok(cosmos)) => Ok(cosmos),
+            Ok(Err(e)) => {
+                node.log_connection_error(e.clone());
+                Err(e)
+            }
+            // Timeout case
+            Err(_) => {
+                let err = ConnectionError::TimeoutConnecting {
+                    grpc_url: node.grpc_url.clone(),
+                };
+                node.log_connection_error(err.clone());
+                Err(err)
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct IdleCleanup {
+    send: tokio::sync::mpsc::Sender<()>,
+}
+
+impl IdleCleanup {
+    fn trigger(&self) {
+        match self.send.try_send(()) {
+            Ok(()) => (),
+            Err(e) => match e {
+                // It's OK if we're full...
+                tokio::sync::mpsc::error::TrySendError::Full(_) => (),
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    unreachable!("IdleCleanup::trigger: channel is closed")
+                }
+            },
+        }
+    }
+
+    async fn new(builder: &CosmosBuilder, idle: Arc<Mutex<Vec<IdleConn>>>) -> Self {
+        let idle_timeout = Duration::from_secs(builder.idle_timeout_seconds().into());
+        let (send, recv) = tokio::sync::mpsc::channel(1);
+        tokio::task::spawn(idle_reaper(idle_timeout, idle, recv));
+        IdleCleanup { send }
+    }
+}
+
+async fn idle_reaper(
+    idle_timeout: Duration,
+    idle: Arc<Mutex<Vec<IdleConn>>>,
+    mut recv: tokio::sync::mpsc::Receiver<()>,
+) {
+    loop {
+        let is_empty = {
+            let mut guard = idle.lock();
+            let old_idle = std::mem::take(&mut *guard);
+            let now = Instant::now();
+            for idle in old_idle {
+                let expires = idle.idle_start + idle_timeout;
+                if expires > now {
+                    guard.push(idle);
+                }
+            }
+            guard.is_empty()
+        };
+
+        if is_empty {
+            // Nothing left to be reaped, so wait for a message on the channel.
+            match recv.recv().await {
+                // New idle connections available, sleep and then loop again
+                Some(()) => (),
+                // Channel has been closed, so we can exit
+                None => break,
+            }
+        }
+
+        // Sleep for the idle timeout period
+        tokio::time::sleep(idle_timeout).await;
+    }
+}

--- a/packages/cosmos/src/cosmos_builder.rs
+++ b/packages/cosmos/src/cosmos_builder.rs
@@ -20,9 +20,8 @@ pub struct CosmosBuilder {
     gas_price_retry_attempts: Option<u64>,
     transaction_attempts: Option<usize>,
     referer_header: Option<String>,
-    connection_count: Option<u32>,
+    connection_count: Option<usize>,
     connection_timeout: Option<Duration>,
-    retry_connection: Option<bool>,
     idle_timeout_seconds: Option<u32>,
     query_timeout_seconds: Option<u32>,
     query_retries: Option<u32>,
@@ -53,7 +52,6 @@ impl CosmosBuilder {
             referer_header: None,
             connection_count: None,
             connection_timeout: None,
-            retry_connection: None,
             idle_timeout_seconds: None,
             query_timeout_seconds: None,
             query_retries: None,
@@ -186,21 +184,21 @@ impl CosmosBuilder {
         self.referer_header = referer_header;
     }
 
-    /// Set the number of bb8 connections
-    pub fn connection_count(&self) -> Option<u32> {
-        self.connection_count
+    /// The maximum number of connections allowed
+    ///
+    /// Defaults to 10
+    pub fn connection_count(&self) -> usize {
+        self.connection_count.unwrap_or(10)
     }
 
     /// See [Self::connection_count]
-    pub fn set_connection_count(&mut self, connection_count: Option<u32>) {
+    pub fn set_connection_count(&mut self, connection_count: Option<usize>) {
         self.connection_count = connection_count;
     }
 
     /// Sets the duration to wait for a connection.
     ///
     /// Defaults to 5 seconds
-    ///
-    /// See [bb8::Builder::connection_timeout]
     pub fn connection_timeout(&self) -> Duration {
         self.connection_timeout
             .unwrap_or_else(|| Duration::from_secs(5))
@@ -209,16 +207,6 @@ impl CosmosBuilder {
     /// See [Self::connection_timeout]
     pub fn set_connection_timeout(&mut self, connection_timeout: Option<Duration>) {
         self.connection_timeout = connection_timeout;
-    }
-
-    /// See [bb8::Builder::retry_connection]
-    pub fn retry_connection(&self) -> Option<bool> {
-        self.retry_connection
-    }
-
-    /// See [Self::retry_connection]
-    pub fn set_retry_connection(&mut self, retry_connection: Option<bool>) {
-        self.retry_connection = retry_connection;
     }
 
     /// Sets the number of seconds before an idle connection is reaped

--- a/packages/cosmos/src/error.rs
+++ b/packages/cosmos/src/error.rs
@@ -137,8 +137,6 @@ pub enum ConnectionError {
         grpc_url: Arc<String>,
         source: Arc<tonic::transport::Error>,
     },
-    #[error("Dropping a fallback connection to {grpc_url}")]
-    DroppingFallbackConnection { grpc_url: Arc<String> },
 }
 
 /// Error while parsing a [crate::ContractAdmin].
@@ -291,8 +289,6 @@ impl Display for StringOrBytes {
 pub enum QueryErrorDetails {
     #[error("Unknown gRPC status returned: {0:?}")]
     Unknown(tonic::Status),
-    #[error("Timed out getting new connection")]
-    ConnectionTimeout,
     #[error("Query timed out")]
     QueryTimeout,
     #[error(transparent)]
@@ -420,8 +416,6 @@ impl QueryErrorDetails {
         match self {
             // Not sure, so give it a retry
             QueryErrorDetails::Unknown(_) => Unsure,
-            // Yup, may as well try to connect again.
-            QueryErrorDetails::ConnectionTimeout => NetworkIssue,
             // Same here, maybe it was a bad connection.
             QueryErrorDetails::QueryTimeout => NetworkIssue,
             // Also possibly a bad connection


### PR DESCRIPTION
Nothing wrong with bb8, but the fallback connection requirements mean we have a heterogenous set of connections, and a standard connection pool library just doesn't provide the facilities we want for managing it. We had a bunch of wonky workarounds to deal with the fact that it was difficult to mark specific endpoints as unhealthy during the connecting phase. This should hopefully simplify things going forward.