### PR TITLE
Leverage request multiplexing in tonic

### DIFF
--- a/packages/cosmos/src/clap.rs
+++ b/packages/cosmos/src/clap.rs
@@ -79,6 +79,9 @@ impl CosmosOpt {
 
     /// Convenient for calling [CosmosOpt::into_builder] and then [CosmosBuilder::build].
     pub async fn build(self) -> Result<Cosmos, CosmosOptError> {
-        Ok(self.into_builder().await?.build_lazy().await)
+        self.into_builder()
+            .await?
+            .build_lazy()
+            .map_err(|source| CosmosOptError::CosmosBuilderError { source })
     }
 }

--- a/packages/cosmos/src/client/node.rs
+++ b/packages/cosmos/src/client/node.rs
@@ -1,0 +1,231 @@
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use tonic::{
+    codegen::InterceptedService,
+    transport::{Channel, ClientTlsConfig, Endpoint},
+};
+
+use crate::{
+    error::{Action, BuilderError, ConnectionError, LastNodeError, SingleNodeHealthReport},
+    Address, CosmosBuilder,
+};
+
+use super::{node_chooser::QueryResult, CosmosInterceptor, SequenceInformation};
+
+/// Internal data structure containing gRPC clients.
+#[derive(Clone)]
+pub(crate) struct Node {
+    node_inner: Arc<NodeInner>,
+}
+
+struct NodeInner {
+    grpc_url: Arc<String>,
+    is_fallback: bool,
+    last_error: RwLock<Option<LastError>>,
+    channel: InterceptedService<Channel, CosmosInterceptor>,
+    simulate_sequences: RwLock<HashMap<Address, SequenceInformation>>,
+    broadcast_sequences: RwLock<HashMap<Address, SequenceInformation>>,
+}
+
+#[derive(Debug)]
+struct LastError {
+    error: Arc<String>,
+    instant: Instant,
+    timestamp: DateTime<Utc>,
+    action: Option<Action>,
+    /// How many network errors in a row have occurred?
+    ///
+    /// Gets reset each time there's a successful query, or a query that fails with a non-network reason.
+    error_count: usize,
+}
+
+impl CosmosBuilder {
+    pub(crate) fn make_node(
+        &self,
+        grpc_url: &Arc<String>,
+        is_fallback: bool,
+    ) -> Result<Node, BuilderError> {
+        let grpc_endpoint =
+            grpc_url
+                .parse::<Endpoint>()
+                .map_err(|source| BuilderError::InvalidGrpcUrl {
+                    grpc_url: grpc_url.clone(),
+                    source: source.into(),
+                })?;
+        let grpc_endpoint = if grpc_url.starts_with("https://") {
+            grpc_endpoint
+                .tls_config(ClientTlsConfig::new())
+                .map_err(|source| BuilderError::TlsConfig {
+                    grpc_url: grpc_url.clone(),
+                    source: source.into(),
+                })?
+        } else {
+            grpc_endpoint
+        };
+        let grpc_channel = grpc_endpoint.connect_lazy();
+
+        let referer_header = self.referer_header().map(|x| x.to_owned());
+
+        let interceptor = CosmosInterceptor(referer_header.map(Arc::new));
+        let channel = InterceptedService::new(grpc_channel, interceptor);
+
+        Ok(Node {
+            node_inner: Arc::new(NodeInner {
+                is_fallback,
+                channel,
+                simulate_sequences: RwLock::new(HashMap::new()),
+                broadcast_sequences: RwLock::new(HashMap::new()),
+                grpc_url: grpc_url.clone(),
+                last_error: RwLock::new(None),
+            }),
+        })
+    }
+}
+
+pub(crate) type CosmosChannel = InterceptedService<Channel, CosmosInterceptor>;
+
+impl Node {
+    pub(crate) fn grpc_url(&self) -> &Arc<String> {
+        &self.node_inner.grpc_url
+    }
+
+    pub(crate) fn simulate_sequences(&self) -> &RwLock<HashMap<Address, SequenceInformation>> {
+        &self.node_inner.simulate_sequences
+    }
+
+    pub(crate) fn broadcast_sequences(&self) -> &RwLock<HashMap<Address, SequenceInformation>> {
+        &self.node_inner.broadcast_sequences
+    }
+
+    pub(crate) fn set_broken(&mut self, err: impl FnOnce(Arc<String>) -> ConnectionError) {
+        let err = err(self.node_inner.grpc_url.clone());
+        self.log_connection_error(err);
+    }
+
+    pub(super) fn log_connection_error(&self, error: ConnectionError) {
+        *self.node_inner.last_error.write() = Some(LastError {
+            error: error.to_string().into(),
+            instant: Instant::now(),
+            timestamp: Utc::now(),
+            action: None,
+            error_count: 1,
+        });
+    }
+
+    pub(super) fn log_query_result(&self, res: QueryResult) {
+        let mut guard = self.node_inner.last_error.write();
+        match res {
+            QueryResult::Success | QueryResult::OtherError => {
+                if let Some(error) = guard.as_mut() {
+                    error.error_count = 0;
+                }
+            }
+            QueryResult::NetworkError { err, action } => {
+                let old_error_count = guard.as_ref().map_or(0, |x| x.error_count);
+                *guard = Some(LastError {
+                    error: err.to_string().into(),
+                    instant: Instant::now(),
+                    timestamp: Utc::now(),
+                    action: Some(action),
+                    error_count: old_error_count + 1,
+                });
+            }
+        }
+    }
+
+    pub(crate) fn is_healthy(&self, allowed_error_count: usize) -> bool {
+        const NODE_ERROR_TIMEOUT: u64 = 30;
+
+        match &*self.node_inner.last_error.read() {
+            None => true,
+            Some(last_error) => {
+                last_error.instant.elapsed().as_secs() > NODE_ERROR_TIMEOUT
+                    || last_error.error_count <= allowed_error_count
+            }
+        }
+    }
+
+    pub(crate) fn health_report(&self, allowed_error_count: usize) -> SingleNodeHealthReport {
+        let guard = self.node_inner.last_error.read();
+        let last_error = guard.as_ref();
+        SingleNodeHealthReport {
+            grpc_url: self.node_inner.grpc_url.clone(),
+            is_fallback: self.node_inner.is_fallback,
+            is_healthy: self.is_healthy(allowed_error_count),
+            error_count: last_error.map_or(0, |last_error| last_error.error_count),
+            last_error: last_error.map(|last_error| {
+                let error = match &last_error.action {
+                    Some(action) => Arc::new(format!(
+                        "{} during action {}",
+                        last_error.error.clone(),
+                        action
+                    )),
+                    None => last_error.error.clone(),
+                };
+                LastNodeError {
+                    timestamp: last_error.timestamp,
+                    age: last_error.instant.elapsed(),
+                    error,
+                }
+            }),
+        }
+    }
+
+    pub(crate) fn auth_query_client(
+        &self,
+    ) -> cosmos_sdk_proto::cosmos::auth::v1beta1::query_client::QueryClient<CosmosChannel> {
+        cosmos_sdk_proto::cosmos::auth::v1beta1::query_client::QueryClient::new(
+            self.node_inner.channel.clone(),
+        )
+    }
+
+    pub(crate) fn bank_query_client(
+        &self,
+    ) -> cosmos_sdk_proto::cosmos::bank::v1beta1::query_client::QueryClient<CosmosChannel> {
+        cosmos_sdk_proto::cosmos::bank::v1beta1::query_client::QueryClient::new(
+            self.node_inner.channel.clone(),
+        )
+    }
+
+    pub(crate) fn wasm_query_client(
+        &self,
+    ) -> cosmos_sdk_proto::cosmwasm::wasm::v1::query_client::QueryClient<CosmosChannel> {
+        cosmos_sdk_proto::cosmwasm::wasm::v1::query_client::QueryClient::new(
+            self.node_inner.channel.clone(),
+        )
+    }
+
+    pub(crate) fn tx_service_client(
+        &self,
+    ) -> cosmos_sdk_proto::cosmos::tx::v1beta1::service_client::ServiceClient<CosmosChannel> {
+        cosmos_sdk_proto::cosmos::tx::v1beta1::service_client::ServiceClient::new(
+            self.node_inner.channel.clone(),
+        )
+    }
+
+    pub(crate) fn tendermint_client(
+        &self,
+    ) -> cosmos_sdk_proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient<
+        CosmosChannel,
+    > {
+        cosmos_sdk_proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient::new(
+            self.node_inner.channel.clone(),
+        )
+    }
+
+    pub(crate) fn authz_query_client(
+        &self,
+    ) -> cosmos_sdk_proto::cosmos::authz::v1beta1::query_client::QueryClient<CosmosChannel> {
+        cosmos_sdk_proto::cosmos::authz::v1beta1::query_client::QueryClient::new(
+            self.node_inner.channel.clone(),
+        )
+    }
+
+    pub(crate) fn epochs_query_client(
+        &self,
+    ) -> crate::osmosis::epochs::query_client::QueryClient<CosmosChannel> {
+        crate::osmosis::epochs::query_client::QueryClient::new(self.node_inner.channel.clone())
+    }
+}

--- a/packages/cosmos/src/client/node_chooser.rs
+++ b/packages/cosmos/src/client/node_chooser.rs
@@ -1,45 +1,34 @@
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
-use parking_lot::RwLock;
 use rand::seq::SliceRandom;
 
 use crate::{
-    error::{
-        Action, ConnectionError, LastNodeError, NodeHealthReport, QueryErrorDetails,
-        SingleNodeHealthReport,
-    },
+    error::{Action, BuilderError, NodeHealthReport, QueryErrorDetails},
     CosmosBuilder,
 };
 
+use super::node::Node;
+
 #[derive(Clone)]
 pub(super) struct NodeChooser {
-    primary: Node,
-    fallbacks: Arc<Vec<Node>>,
+    primary: Arc<Node>,
+    fallbacks: Arc<[Node]>,
     /// How many errors in a row are allowed before we call a node unhealthy?
     allowed_error_count: usize,
 }
 
 impl NodeChooser {
-    pub(super) fn new(builder: &CosmosBuilder) -> Self {
-        NodeChooser {
-            primary: Node {
-                grpc_url: builder.grpc_url_arc().clone(),
-                is_fallback: false,
-                last_error: Arc::new(RwLock::new(None)),
-            },
+    pub(super) fn new(builder: &CosmosBuilder) -> Result<Self, BuilderError> {
+        Ok(NodeChooser {
+            primary: Arc::new(builder.make_node(builder.grpc_url_arc(), false)?),
             fallbacks: builder
                 .grpc_fallback_urls()
                 .iter()
-                .map(|fallback| Node {
-                    grpc_url: fallback.clone(),
-                    is_fallback: true,
-                    last_error: Arc::new(RwLock::new(None)),
-                })
-                .collect::<Vec<_>>()
+                .map(|fallback| builder.make_node(fallback, true))
+                .collect::<Result<Vec<_>, _>>()?
                 .into(),
             allowed_error_count: builder.get_allowed_error_count(),
-        }
+        })
     }
 
     pub(super) fn choose_node(&self) -> &Node {
@@ -73,30 +62,9 @@ impl NodeChooser {
     }
 
     pub(super) fn all_nodes(&self) -> impl Iterator<Item = &Node> {
-        std::iter::once(&self.primary).chain(self.fallbacks.iter())
+        std::iter::once(&*self.primary).chain(self.fallbacks.iter())
     }
 }
-
-#[derive(Clone)]
-pub(super) struct Node {
-    pub(super) grpc_url: Arc<String>,
-    pub(super) is_fallback: bool,
-    last_error: Arc<RwLock<Option<LastError>>>,
-}
-
-#[derive(Debug)]
-struct LastError {
-    error: Arc<String>,
-    instant: Instant,
-    timestamp: DateTime<Utc>,
-    action: Option<Action>,
-    /// How many network errors in a row have occurred?
-    ///
-    /// Gets reset each time there's a successful query, or a query that fails with a non-network reason.
-    error_count: usize,
-}
-
-const NODE_ERROR_TIMEOUT: u64 = 30;
 
 pub(crate) enum QueryResult {
     Success,
@@ -105,73 +73,4 @@ pub(crate) enum QueryResult {
         action: Action,
     },
     OtherError,
-}
-
-impl Node {
-    pub(super) fn log_connection_error(&self, error: ConnectionError) {
-        *self.last_error.write() = Some(LastError {
-            error: error.to_string().into(),
-            instant: Instant::now(),
-            timestamp: Utc::now(),
-            action: None,
-            error_count: 1,
-        });
-    }
-
-    pub(super) fn log_query_result(&self, res: QueryResult) {
-        let mut guard = self.last_error.write();
-        match res {
-            QueryResult::Success | QueryResult::OtherError => {
-                if let Some(error) = guard.as_mut() {
-                    error.error_count = 0;
-                }
-            }
-            QueryResult::NetworkError { err, action } => {
-                let old_error_count = guard.as_ref().map_or(0, |x| x.error_count);
-                *guard = Some(LastError {
-                    error: err.to_string().into(),
-                    instant: Instant::now(),
-                    timestamp: Utc::now(),
-                    action: Some(action),
-                    error_count: old_error_count + 1,
-                });
-            }
-        }
-    }
-
-    fn is_healthy(&self, allowed_error_count: usize) -> bool {
-        match &*self.last_error.read() {
-            None => true,
-            Some(last_error) => {
-                last_error.instant.elapsed().as_secs() > NODE_ERROR_TIMEOUT
-                    || last_error.error_count <= allowed_error_count
-            }
-        }
-    }
-
-    fn health_report(&self, allowed_error_count: usize) -> SingleNodeHealthReport {
-        let guard = self.last_error.read();
-        let last_error = guard.as_ref();
-        SingleNodeHealthReport {
-            grpc_url: self.grpc_url.clone(),
-            is_fallback: self.is_fallback,
-            is_healthy: self.is_healthy(allowed_error_count),
-            error_count: last_error.map_or(0, |last_error| last_error.error_count),
-            last_error: last_error.map(|last_error| {
-                let error = match &last_error.action {
-                    Some(action) => Arc::new(format!(
-                        "{} during action {}",
-                        last_error.error.clone(),
-                        action
-                    )),
-                    None => last_error.error.clone(),
-                };
-                LastNodeError {
-                    timestamp: last_error.timestamp,
-                    age: last_error.instant.elapsed(),
-                    error,
-                }
-            }),
-        }
-    }
 }

--- a/packages/cosmos/src/client/pool.rs
+++ b/packages/cosmos/src/client/pool.rs
@@ -1,185 +1,70 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::sync::Arc;
 
-use parking_lot::Mutex;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-use crate::{error::ConnectionError, CosmosBuilder};
+use crate::{
+    error::{BuilderError, ConnectionError},
+    CosmosBuilder,
+};
 
-use super::{node_chooser::NodeChooser, CosmosInner};
+use super::{node::Node, node_chooser::NodeChooser};
 
 #[derive(Clone)]
 pub(super) struct Pool {
     pub(super) builder: Arc<CosmosBuilder>,
     pub(super) node_chooser: NodeChooser,
+    /// Permits for enforcing global concurrent request count.
     semaphore: Arc<Semaphore>,
-    idle: Arc<Mutex<Vec<IdleConn>>>,
-    idle_cleanup: IdleCleanup,
 }
 
-struct IdleConn {
-    conn: CosmosInner,
-    idle_start: Instant,
-}
-
-pub(super) struct CosmosInnerGuard {
-    /// Only switches to None on drop
-    pub(super) inner: Option<CosmosInner>,
+pub(super) struct NodeGuard {
+    pub(super) inner: Node,
     _permit: OwnedSemaphorePermit,
-    idle: Arc<Mutex<Vec<IdleConn>>>,
-    idle_cleanup: IdleCleanup,
 }
 
-impl CosmosInnerGuard {
-    pub(crate) fn get_inner_mut(&mut self) -> &mut CosmosInner {
-        self.inner
-            .as_mut()
-            .expect("CosmosInnerGuard::get_inner_mut: inner is None")
-    }
-}
-
-impl CosmosInner {
-    fn is_expired(&self) -> bool {
-        self.expires
-            .map_or(false, |expires| expires <= tokio::time::Instant::now())
-    }
-}
-
-impl Drop for CosmosInnerGuard {
-    fn drop(&mut self) {
-        let inner = self
-            .inner
-            .take()
-            .expect("CosmosInnerGuard::drop: inner is None");
-        if !inner.is_expired() && !inner.is_broken {
-            self.idle.lock().push(IdleConn {
-                conn: inner,
-                idle_start: Instant::now(),
-            });
-            self.idle_cleanup.trigger();
-        }
+impl NodeGuard {
+    pub(crate) fn get_inner_mut(&mut self) -> &mut Node {
+        &mut self.inner
     }
 }
 
 impl Pool {
-    pub(super) async fn new(builder: Arc<CosmosBuilder>) -> Self {
-        let node_chooser = NodeChooser::new(&builder);
-        let semaphore = Arc::new(Semaphore::new(builder.connection_count()));
-        let idle = Arc::new(Mutex::new(Vec::new()));
-        let idle_cleanup = IdleCleanup::new(&builder, idle.clone()).await;
-        Pool {
+    pub(super) fn new(builder: Arc<CosmosBuilder>) -> Result<Self, BuilderError> {
+        let node_chooser = NodeChooser::new(&builder)?;
+        let semaphore = Arc::new(Semaphore::new(builder.request_count()));
+        Ok(Pool {
             builder,
             node_chooser,
             semaphore,
-            idle,
-            idle_cleanup,
-        }
+        })
     }
 
-    pub(super) async fn get(&self) -> Result<CosmosInnerGuard, ConnectionError> {
+    pub(super) async fn get(&self) -> Result<NodeGuard, ConnectionError> {
         let permit = self
             .semaphore
             .clone()
             .acquire_owned()
             .await
             .expect("Pool::get: semaphore has been closed");
-        while let Some(idle) = self.idle.lock().pop() {
-            if !idle.conn.is_expired() {
-                return Ok(CosmosInnerGuard {
-                    inner: Some(idle.conn),
-                    _permit: permit,
-                    idle: self.idle.clone(),
-                    idle_cleanup: self.idle_cleanup.clone(),
-                });
-            }
-        }
 
-        let inner = self.fresh().await?;
-        Ok(CosmosInnerGuard {
-            inner: Some(inner),
+        let node = self.node_chooser.choose_node();
+        Ok(NodeGuard {
+            inner: node.clone(),
             _permit: permit,
-            idle: self.idle.clone(),
-            idle_cleanup: self.idle_cleanup.clone(),
         })
     }
 
-    async fn fresh(&self) -> Result<CosmosInner, ConnectionError> {
-        let node = self.node_chooser.choose_node();
+    pub(crate) async fn get_with_node(&self, node: &Node) -> Result<NodeGuard, ConnectionError> {
+        let permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("Pool::get_with_node: semaphore has been closed");
 
-        let build = self.builder.build_inner(node, &self.builder);
-        let build = tokio::time::timeout(self.builder.connection_timeout(), build);
-
-        match build.await {
-            Ok(Ok(cosmos)) => Ok(cosmos),
-            Ok(Err(e)) => {
-                node.log_connection_error(e.clone());
-                Err(e)
-            }
-            // Timeout case
-            Err(_) => {
-                let err = ConnectionError::TimeoutConnecting {
-                    grpc_url: node.grpc_url.clone(),
-                };
-                node.log_connection_error(err.clone());
-                Err(err)
-            }
-        }
-    }
-}
-
-#[derive(Clone)]
-struct IdleCleanup {
-    send: tokio::sync::mpsc::Sender<()>,
-}
-
-impl IdleCleanup {
-    fn trigger(&self) {
-        // Ignore errors. If it's because the channel is full: no big deal,
-        // that's by design. If it's closed: this can happen during cleanup of
-        // an application.
-        self.send.try_send(()).ok();
-    }
-
-    async fn new(builder: &CosmosBuilder, idle: Arc<Mutex<Vec<IdleConn>>>) -> Self {
-        let idle_timeout = Duration::from_secs(builder.idle_timeout_seconds().into());
-        let (send, recv) = tokio::sync::mpsc::channel(1);
-        tokio::task::spawn(idle_reaper(idle_timeout, idle, recv));
-        IdleCleanup { send }
-    }
-}
-
-async fn idle_reaper(
-    idle_timeout: Duration,
-    idle: Arc<Mutex<Vec<IdleConn>>>,
-    mut recv: tokio::sync::mpsc::Receiver<()>,
-) {
-    loop {
-        let is_empty = {
-            let mut guard = idle.lock();
-            let old_idle = std::mem::take(&mut *guard);
-            let now = Instant::now();
-            for idle in old_idle {
-                let expires = idle.idle_start + idle_timeout;
-                if expires > now {
-                    guard.push(idle);
-                }
-            }
-            guard.is_empty()
-        };
-
-        if is_empty {
-            // Nothing left to be reaped, so wait for a message on the channel.
-            match recv.recv().await {
-                // New idle connections available, sleep and then loop again
-                Some(()) => (),
-                // Channel has been closed, so we can exit
-                None => break,
-            }
-        }
-
-        // Sleep for the idle timeout period
-        tokio::time::sleep(idle_timeout).await;
+        Ok(NodeGuard {
+            inner: node.clone(),
+            _permit: permit,
+        })
     }
 }

--- a/packages/cosmos/src/client/query.rs
+++ b/packages/cosmos/src/client/query.rs
@@ -22,11 +22,11 @@ use cosmos_sdk_proto::{
         QuerySmartContractStateRequest, QuerySmartContractStateResponse,
     },
 };
-use tonic::{async_trait, codegen::InterceptedService, transport::Channel};
+use tonic::async_trait;
 
 use crate::osmosis::epochs::{QueryEpochsInfoRequest, QueryEpochsInfoResponse};
 
-use super::{CosmosInner, CosmosInterceptor};
+use super::node::Node;
 
 #[async_trait]
 pub(crate) trait GrpcRequest: Clone + Sized {
@@ -34,7 +34,7 @@ pub(crate) trait GrpcRequest: Clone + Sized {
 
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status>;
 }
 
@@ -43,7 +43,7 @@ impl GrpcRequest for QueryAccountRequest {
     type Response = QueryAccountResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.auth_query_client().account(req).await
     }
@@ -54,7 +54,7 @@ impl GrpcRequest for QueryAllBalancesRequest {
     type Response = QueryAllBalancesResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.bank_query_client().all_balances(req).await
     }
@@ -65,7 +65,7 @@ impl GrpcRequest for QuerySmartContractStateRequest {
     type Response = QuerySmartContractStateResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().smart_contract_state(req).await
     }
@@ -76,7 +76,7 @@ impl GrpcRequest for QueryRawContractStateRequest {
     type Response = QueryRawContractStateResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().raw_contract_state(req).await
     }
@@ -87,7 +87,7 @@ impl GrpcRequest for QueryCodeRequest {
     type Response = QueryCodeResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().code(req).await
     }
@@ -98,7 +98,7 @@ impl GrpcRequest for GetTxRequest {
     type Response = GetTxResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().get_tx(req).await
     }
@@ -109,7 +109,7 @@ impl GrpcRequest for GetTxsEventRequest {
     type Response = GetTxsEventResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().get_txs_event(req).await
     }
@@ -120,7 +120,7 @@ impl GrpcRequest for QueryContractInfoRequest {
     type Response = QueryContractInfoResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().contract_info(req).await
     }
@@ -131,7 +131,7 @@ impl GrpcRequest for QueryContractHistoryRequest {
     type Response = QueryContractHistoryResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().contract_history(req).await
     }
@@ -142,7 +142,7 @@ impl GrpcRequest for GetBlockByHeightRequest {
     type Response = GetBlockByHeightResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tendermint_client().get_block_by_height(req).await
     }
@@ -153,7 +153,7 @@ impl GrpcRequest for GetLatestBlockRequest {
     type Response = GetLatestBlockResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tendermint_client().get_latest_block(req).await
     }
@@ -164,7 +164,7 @@ impl GrpcRequest for SimulateRequest {
     type Response = SimulateResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().simulate(req).await
     }
@@ -175,7 +175,7 @@ impl GrpcRequest for BroadcastTxRequest {
     type Response = BroadcastTxResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().broadcast_tx(req).await
     }
@@ -186,7 +186,7 @@ impl GrpcRequest for QueryGranterGrantsRequest {
     type Response = QueryGranterGrantsResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.authz_query_client().granter_grants(req).await
     }
@@ -197,7 +197,7 @@ impl GrpcRequest for QueryGranteeGrantsRequest {
     type Response = QueryGranteeGrantsResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.authz_query_client().grantee_grants(req).await
     }
@@ -208,66 +208,8 @@ impl GrpcRequest for QueryEpochsInfoRequest {
     type Response = QueryEpochsInfoResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut CosmosInner,
+        inner: &mut Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.epochs_query_client().epoch_infos(req).await
-    }
-}
-
-type CosmosChannel = InterceptedService<Channel, CosmosInterceptor>;
-
-impl CosmosInner {
-    fn auth_query_client(
-        &self,
-    ) -> cosmos_sdk_proto::cosmos::auth::v1beta1::query_client::QueryClient<CosmosChannel> {
-        cosmos_sdk_proto::cosmos::auth::v1beta1::query_client::QueryClient::new(
-            self.channel.clone(),
-        )
-    }
-
-    fn bank_query_client(
-        &self,
-    ) -> cosmos_sdk_proto::cosmos::bank::v1beta1::query_client::QueryClient<CosmosChannel> {
-        cosmos_sdk_proto::cosmos::bank::v1beta1::query_client::QueryClient::new(
-            self.channel.clone(),
-        )
-    }
-
-    fn wasm_query_client(
-        &self,
-    ) -> cosmos_sdk_proto::cosmwasm::wasm::v1::query_client::QueryClient<CosmosChannel> {
-        cosmos_sdk_proto::cosmwasm::wasm::v1::query_client::QueryClient::new(self.channel.clone())
-    }
-
-    fn tx_service_client(
-        &self,
-    ) -> cosmos_sdk_proto::cosmos::tx::v1beta1::service_client::ServiceClient<CosmosChannel> {
-        cosmos_sdk_proto::cosmos::tx::v1beta1::service_client::ServiceClient::new(
-            self.channel.clone(),
-        )
-    }
-
-    fn tendermint_client(
-        &self,
-    ) -> cosmos_sdk_proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient<
-        CosmosChannel,
-    > {
-        cosmos_sdk_proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient::new(
-            self.channel.clone(),
-        )
-    }
-
-    fn authz_query_client(
-        &self,
-    ) -> cosmos_sdk_proto::cosmos::authz::v1beta1::query_client::QueryClient<CosmosChannel> {
-        cosmos_sdk_proto::cosmos::authz::v1beta1::query_client::QueryClient::new(
-            self.channel.clone(),
-        )
-    }
-
-    fn epochs_query_client(
-        &self,
-    ) -> crate::osmosis::epochs::query_client::QueryClient<CosmosChannel> {
-        crate::osmosis::epochs::query_client::QueryClient::new(self.channel.clone())
     }
 }

--- a/packages/cosmos/src/cosmos_builder.rs
+++ b/packages/cosmos/src/cosmos_builder.rs
@@ -21,7 +21,7 @@ pub struct CosmosBuilder {
     gas_price_retry_attempts: Option<u64>,
     transaction_attempts: Option<usize>,
     referer_header: Option<String>,
-    connection_count: Option<usize>,
+    request_count: Option<usize>,
     connection_timeout: Option<Duration>,
     idle_timeout_seconds: Option<u32>,
     query_timeout_seconds: Option<u32>,
@@ -54,7 +54,7 @@ impl CosmosBuilder {
             gas_price_retry_attempts: None,
             transaction_attempts: None,
             referer_header: None,
-            connection_count: None,
+            request_count: None,
             connection_timeout: None,
             idle_timeout_seconds: None,
             query_timeout_seconds: None,
@@ -219,16 +219,18 @@ impl CosmosBuilder {
         self.referer_header = referer_header;
     }
 
-    /// The maximum number of connections allowed
+    /// The maximum number of concurrent requests
     ///
-    /// Defaults to 10
-    pub fn connection_count(&self) -> usize {
-        self.connection_count.unwrap_or(10)
+    /// This is a global limit for the generated [Cosmos], and will apply across all endpoints.
+    ///
+    /// Defaults to 128
+    pub fn request_count(&self) -> usize {
+        self.request_count.unwrap_or(128)
     }
 
-    /// See [Self::connection_count]
-    pub fn set_connection_count(&mut self, connection_count: Option<usize>) {
-        self.connection_count = connection_count;
+    /// See [Self::request_count]
+    pub fn set_request_count(&mut self, request_count: Option<usize>) {
+        self.request_count = request_count;
     }
 
     /// Sets the duration to wait for a connection.

--- a/packages/cosmos/src/error.rs
+++ b/packages/cosmos/src/error.rs
@@ -63,6 +63,16 @@ pub enum WalletError {
 /// Errors that can occur while building a connection.
 #[derive(thiserror::Error, Debug)]
 pub enum BuilderError {
+    #[error("Invalid gRPC URL: {grpc_url}: {source:?}")]
+    InvalidGrpcUrl {
+        grpc_url: Arc<String>,
+        source: Arc<tonic::transport::Error>,
+    },
+    #[error("Unable to configure TLS for {grpc_url}: {source:?}")]
+    TlsConfig {
+        grpc_url: Arc<String>,
+        source: Arc<tonic::transport::Error>,
+    },
     #[error("Error downloading chain information from {url}: {source:?}")]
     DownloadChainInfo { url: String, source: reqwest::Error },
     #[error("Unknown Cosmos network value {network:?}")]
@@ -111,16 +121,6 @@ pub enum ChainParseError {
 /// This could be the initial connection or sending a new query.
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum ConnectionError {
-    #[error("Invalid gRPC URL: {grpc_url}: {source:?}")]
-    InvalidGrpcUrl {
-        grpc_url: Arc<String>,
-        source: Arc<tonic::transport::Error>,
-    },
-    #[error("Unable to configure TLS when connecting to {grpc_url}: {source:?}")]
-    TlsConfig {
-        grpc_url: Arc<String>,
-        source: Arc<tonic::transport::Error>,
-    },
     #[error("Sanity check on connection to {grpc_url} failed with gRPC status {source}")]
     SanityCheckFailed {
         grpc_url: Arc<String>,
@@ -132,11 +132,6 @@ pub enum ConnectionError {
     TimeoutQuery { grpc_url: Arc<String> },
     #[error("Timeout hit when connecting to gRPC endpoint {grpc_url}")]
     TimeoutConnecting { grpc_url: Arc<String> },
-    #[error("Cannot establish connection to {grpc_url}: {source:?}")]
-    CannotEstablishConnection {
-        grpc_url: Arc<String>,
-        source: Arc<tonic::transport::Error>,
-    },
 }
 
 /// Error while parsing a [crate::ContractAdmin].


### PR DESCRIPTION
The basic idea here is twofold:

1. Instead of doing connection pool management ourselves, rely on tonic/hyper to do it.
2. Clone the underlying Channel so that we can reuse the same connection for multiple concurrent requests.