### PR TITLE
Using rustls for reqwest

### DIFF
--- a/packages/cosmos/Cargo.toml
+++ b/packages/cosmos/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1"
 chrono = "0.4.31"
 hex = "0.4"
 sha2 = "0.10"
-reqwest = { version = "0.11.14", default-features = false, features = ["json", "gzip", "brotli"] }
+reqwest = { version = "0.11.14", default-features = false, features = ["json", "gzip", "brotli", "rustls-tls"] }
 base64 = "0.21"
 parking_lot = "0.12"
 clap = { version = "4", features = ["derive", "env"], optional = true }


### PR DESCRIPTION
I hit a problem with this on the exploit detector. Seems like it was trying to fetch gas config for Sei and failing on:

```
pid1-rs: Process not running as Pid 1: PID 418466
2024-02-29T10:52:04.924418Z ERROR exploit_detector: Error downloading chain information from https://raw.githubusercontent.com/sei-protocol/chain-registry/master/gas.json: reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("raw.githubusercontent.com")), port: None, path: "/sei-protocol/chain-registry/master/gas.json", query: None, fragment: None }, source: hyper::Error(Connect, "invalid URL, scheme is not http") }
Error: Error downloading chain information from https://raw.githubusercontent.com/sei-protocol/chain-registry/master/gas.json: reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("raw.githubusercontent.com")), port: None, path: "/sei-protocol/chain-registry/master/gas.json", query: None, fragment: None }, source: hyper::Error(Connect, "invalid URL, scheme is not http") }

```