### PR TITLE
PERP-3276 | Update gas config URL for SeiMainnet

### DIFF
--- a/packages/cosmos/src/cosmos_network.rs
+++ b/packages/cosmos/src/cosmos_network.rs
@@ -222,7 +222,7 @@ impl CosmosNetwork {
                 }
 
                 let gas_config = load_json::<SeiGasConfig>(
-                    "https://raw.githubusercontent.com/sei-protocol/chain-registry/master/gas.json",
+                    "http://raw.githubusercontent.com/sei-protocol/chain-registry/master/gas.json",
                     client,
                 )
                 .await?;
@@ -245,7 +245,7 @@ impl CosmosNetwork {
                 }
 
                 let gas_config = load_json::<SeiGasConfig>(
-                "https://raw.githubusercontent.com/sei-protocol/testnet-registry/master/gas.json",
+                "http://raw.githubusercontent.com/sei-protocol/testnet-registry/master/gas.json",
                     client,
                 )
                 .await?;


### PR DESCRIPTION
@lvn-hasky-dragon , while working on [PERP-3276 ](https://phobosfinance.atlassian.net/browse/PERP-3276), I noticed that `levana-cosmos-rs` throws an error because of `reqwest` version update from `levana-querier`.
I see that changing https into http from gas-config url of SeiMainnet resolve this issue.